### PR TITLE
Use wrappers for boolean types

### DIFF
--- a/config.proto
+++ b/config.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 option go_package = "github.com/hypertrace/agent-config/config";
 
+import "google/protobuf/wrappers.proto";
+
 // AgentConfig covers the config for agents
 message AgentConfig {
     // serviceName identifies the service/process running
@@ -21,16 +23,16 @@ message Reporting {
     string address = 1;
 
     // secure when false, permits connecting to the trace endpoint without a certificate
-    bool secure = 2;
+    google.protobuf.BoolValue secure = 2;
 }
 
 // Message describes what message should be considered for certain DataCapture option
 message Message {
     // request describes the outgoing/incoming message in a client/request operation
-    bool request = 1;
+    google.protobuf.BoolValue request = 1;
 
     // response describes the incoming/outgoing message in a client/request operation
-    bool response = 2;
+    google.protobuf.BoolValue response = 2;
 }
 
 // DataCapture describes the elements to be captured by the agent instrumentation

--- a/config.proto
+++ b/config.proto
@@ -20,7 +20,7 @@ message AgentConfig {
 // tracing server o collector.
 message Reporting {
     // address represents the host for reporting the traes e.g. api.traceable.ai
-    string address = 1;
+    google.protobuf.StringValue address = 1;
 
     // secure when false, permits connecting to the trace endpoint without a certificate
     google.protobuf.BoolValue secure = 2;

--- a/config.proto
+++ b/config.proto
@@ -1,8 +1,8 @@
 syntax = "proto3";
 
-option go_package = "github.com/hypertrace/agent-config/config";
-
 import "google/protobuf/wrappers.proto";
+
+option go_package = "github.com/hypertrace/agent-config/config";
 
 // AgentConfig covers the config for agents
 message AgentConfig {


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <pavol.loffay@traceable.ai>

Use wrappers to be able to check if the value was explicitly set to false by user.

Resolves #14 