### PR TITLE
Rename trace_context to tracecontext to align with OTEL

### DIFF
--- a/.protolint.yaml
+++ b/.protolint.yaml
@@ -4,6 +4,7 @@ lint:
     remove:
       - FIELD_NAMES_LOWER_SNAKE_CASE
       - ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
+      - ENUM_FIELD_NAMES_UPPER_SNAKE_CASE
 
   rules_option:
     # MAX_LINE_LENGTH rule option.

--- a/config.proto
+++ b/config.proto
@@ -79,9 +79,9 @@ message DataCapture {
 enum PropagationFormat {
     // B3 propagation format, agents should support both multi and single value formats
     // see https://github.com/openzipkin/b3-propagation
-    B3 = 0;
+    b3 = 0;
 
     // W3C Propagation format
     // see https://www.w3.org/TR/trace-context/
-    TRACECONTEXT = 1;
+    tracecontext = 1;
 }

--- a/config.proto
+++ b/config.proto
@@ -83,5 +83,5 @@ enum PropagationFormat {
 
     // W3C Propagation format
     // see https://www.w3.org/TR/trace-context/
-    TRACE_CONTEXT = 1;
+    TRACECONTEXT = 1;
 }


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

I know that this has been discussed but I would like to reconsider it to avoid ugly conversions:
* https://github.com/hypertrace/javaagent/pull/119/files#diff-741828b7f497a297df5c202dd6b9a67e902baaab21143331fc930bdbb81adff0R63
