### PR TITLE
Change align trace contex propagation name with OTEL

### DIFF
--- a/config.proto
+++ b/config.proto
@@ -84,5 +84,5 @@ enum PropagationFormat {
 
     // W3C Propagation format
     // see https://www.w3.org/TR/trace-context/
-    TRACE_CONTEXT = 1;
+    TRACECONTEXT = 1;
 }


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

Our agents are based on OTEL and OTEL uses `tracecontext` name for the W3C Trace-Context. This change makes it easier to transform the names from HT-config to OTEL trace context propagation name. 