### PR TITLE
Add span attribute max length

### DIFF
--- a/config.proto
+++ b/config.proto
@@ -77,6 +77,9 @@ message DataCapture {
 
     // rpcBody enables/disables the capture of the request/response body in RPC
     Message rpcBody = 4;
+
+    // maximum value of span's attribute value in characters. Default should be 128.
+    google.protobuf.Int32Value attributeValueMaxLength = 5;
 }
 
 // PropagationFormat represents the propagation formats supported by agents

--- a/config.proto
+++ b/config.proto
@@ -78,8 +78,8 @@ message DataCapture {
     // rpcBody enables/disables the capture of the request/response body in RPC
     Message rpcBody = 4;
 
-    // maximum value of span's attribute value in characters. Default should be 128_000.
-    google.protobuf.Int32Value bodyAttributeMaxSizeBytes = 5;
+    // maximum size of captured body in bytes. Default should be 131_072 (128 KiB).
+    google.protobuf.Int32Value bodyMaxSizeBytes = 5;
 }
 
 // PropagationFormat represents the propagation formats supported by agents

--- a/config.proto
+++ b/config.proto
@@ -78,8 +78,8 @@ message DataCapture {
     // rpcBody enables/disables the capture of the request/response body in RPC
     Message rpcBody = 4;
 
-    // maximum value of span's attribute value in characters. Default should be 128.
-    google.protobuf.Int32Value attributeValueMaxLength = 5;
+    // maximum value of span's attribute value in characters. Default should be 128_000.
+    google.protobuf.Int32Value bodyAttributeMaxSizeBytes = 5;
 }
 
 // PropagationFormat represents the propagation formats supported by agents


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>

This PR adds configuration for span's attribute value max length. Our current agents use 128 characters by default.

Here are the other properties that OTEL java exposes https://github.com/open-telemetry/opentelemetry-java/blob/91dc1191813a887caba594d483fe8718ce79d7fc/sdk/trace/src/main/java/io/opentelemetry/sdk/trace/config/TraceConfig.java#L32 
* max number of attributes, events, links