### PR TITLE
Update the casing of the fields from camel to snake

### DIFF
--- a/.protolint.yaml
+++ b/.protolint.yaml
@@ -2,7 +2,6 @@ lint:
   rules:
     all_default: true
     remove:
-      - FIELD_NAMES_LOWER_SNAKE_CASE
       - ENUM_FIELD_NAMES_ZERO_VALUE_END_WITH
 
   rules_option:

--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -13,6 +13,7 @@ Agents can be configured using environment variables:
 | HT_REPORTING_TOKEN | User specific token to access Traceable API |
 | HT_REPORTING_OPA_ENDPOINT | Represents the endpoint for polling OPA config file e.g. http://opa.traceableai:8181/ |
 | HT_REPORTING_OPA_POLL_PERIOD_SECONDS | Poll period in seconds to query OPA service |
+| HT_REPORTING_OPA_ENABLED | When `true` Open Policy Agent evaluation is enabled to block request |
 | HT_DATA_CAPTURE_HTTP_HEADERS_REQUEST | When `false` it disables the capture for the request in a client/request operation |
 | HT_DATA_CAPTURE_HTTP_HEADERS_RESPONSE | When `false` it disables the capture for the response in a client/request operation |
 | HT_DATA_CAPTURE_HTTP_BODY_REQUEST | When `false` it disables the capture for the request in a client/request operation |
@@ -21,3 +22,4 @@ Agents can be configured using environment variables:
 | HT_DATA_CAPTURE_RPC_METADATA_RESPONSE | When `false` it disables the capture for the response in a client/request operation |
 | HT_DATA_CAPTURE_RPC_BODY_REQUEST | When `false` it disables the capture for the request in a client/request operation |
 | HT_DATA_CAPTURE_RPC_BODY_RESPONSE | When `false` it disables the capture for the response in a client/request operation |
+| HT_DATA_CAPTURE_BODY_MAX_SIZE_BYTES | Maximum size of captured body in bytes. Default should be 131_072 (128 KiB). |

--- a/README.md
+++ b/README.md
@@ -26,3 +26,8 @@ protolint config.proto
 
 [ci-img]: https://github.com/hypertrace/agent-config/workflows/lint%20protobuf/badge.svg
 [ci]: https://github.com/hypertrace/agent-config/actions
+
+Initialize the git submodules before generating the env vars.
+```bash
+git submodule update  --init  --recursive
+```

--- a/config.proto
+++ b/config.proto
@@ -13,17 +13,17 @@ option java_package = "org.hypertrace.agent.config";
 // Since the wrappers change structure of the objects the marshalling and unmarshalling
 // have to be done via protobuf marshallers.
 message AgentConfig {
-    // serviceName identifies the service/process running e.g. "my service"
-    google.protobuf.StringValue serviceName = 1;
+    // service_name identifies the service/process running e.g. "my service"
+    google.protobuf.StringValue service_name = 1;
 
     // reporting holds the reporting settings for the agent
     Reporting reporting = 2;
 
-    // dataCapture describes the data being captured by instrumentation
-    DataCapture dataCapture = 3;
+    // data_capture describes the data being captured by instrumentation
+    DataCapture data_capture = 3;
 
-    // propagationFormats list the supported propagation formats
-    repeated PropagationFormat propagationFormats = 4;
+    // propagation_formats list the supported propagation formats
+    repeated PropagationFormat propagation_formats = 4;
 }
 
 // Reporting covers the options related to the mechanics for sending data to the
@@ -49,7 +49,7 @@ message Opa {
     google.protobuf.StringValue endpoint = 1;
 
     // poll period in seconds to query OPA service
-    google.protobuf.Int32Value pollPeriodSeconds  = 2;
+    google.protobuf.Int32Value poll_period_seconds  = 2;
 
     // when `true` Open Policy Agent evaluation is enabled to block request
     google.protobuf.BoolValue enabled = 3;
@@ -66,20 +66,20 @@ message Message {
 
 // DataCapture describes the elements to be captured by the agent instrumentation
 message DataCapture {
-    // httpHeaders enables/disables the capture of the request/response headers in HTTP
-    Message httpHeaders = 1;
+    // http_headers enables/disables the capture of the request/response headers in HTTP
+    Message http_headers = 1;
 
-    // httpBody enables/disables the capture of the request/response body in HTTP
-    Message httpBody = 2;
+    // http_body enables/disables the capture of the request/response body in HTTP
+    Message http_body = 2;
 
-    // rpcMetadata enables/disables the capture of the request/response metadata in RPC
-    Message rpcMetadata = 3;
+    // rpc_metadata enables/disables the capture of the request/response metadata in RPC
+    Message rpc_metadata = 3;
 
-    // rpcBody enables/disables the capture of the request/response body in RPC
-    Message rpcBody = 4;
+    // rpc_body enables/disables the capture of the request/response body in RPC
+    Message rpc_body = 4;
 
     // maximum size of captured body in bytes. Default should be 131_072 (128 KiB).
-    google.protobuf.Int32Value bodyMaxSizeBytes = 5;
+    google.protobuf.Int32Value body_max_size_bytes = 5;
 }
 
 // PropagationFormat represents the propagation formats supported by agents


### PR DESCRIPTION
Proto style guide defines that the naming of field name
should be in snake casing.