### PR TITLE
Add enabled flag in agent config

### DIFF
--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -23,3 +23,4 @@ Agents can be configured using environment variables:
 | HT_DATA_CAPTURE_RPC_BODY_REQUEST | When `false` it disables the capture for the request in a client/request operation |
 | HT_DATA_CAPTURE_RPC_BODY_RESPONSE | When `false` it disables the capture for the response in a client/request operation |
 | HT_DATA_CAPTURE_BODY_MAX_SIZE_BYTES | Maximum size of captured body in bytes. Default should be 131_072 (128 KiB). |
+| HT_ENABLED | When `false`, disables the agent |

--- a/config.proto
+++ b/config.proto
@@ -24,6 +24,9 @@ message AgentConfig {
 
     // propagation_formats list the supported propagation formats
     repeated PropagationFormat propagation_formats = 4;
+
+    // when `false`, disables the agent
+    google.protobuf.BoolValue enabled = 5;
 }
 
 // Reporting covers the options related to the mechanics for sending data to the


### PR DESCRIPTION
When `enabled` is set to false, the Agent will not be enabled and
will effectively become a no-op.

Closes #45