### PR TITLE
Adds resources field in Agent Config

### DIFF
--- a/config.proto
+++ b/config.proto
@@ -31,6 +31,7 @@ message AgentConfig {
     // javaagent has the configs specific to javaagent
     JavaAgent javaagent = 6;
 
+    // resources map define the static list of resources which is configured on the tracer
     map<string, string> resources = 7;
 }
 
@@ -51,7 +52,6 @@ message Reporting {
 
     // reporter type. Defaults to zipkin, in the future it will change to otlp.
     TraceReporterType trace_reporter_type = 5;
-
 }
 
 // Opa covers the options related to the mechanics for getting Open Policy Agent configuration file.

--- a/config.proto
+++ b/config.proto
@@ -30,6 +30,8 @@ message AgentConfig {
 
     // javaagent has the configs specific to javaagent
     JavaAgent javaagent = 6;
+
+    map<string, string> resources = 7;
 }
 
 // Reporting covers the options related to the mechanics for sending data to the
@@ -49,6 +51,7 @@ message Reporting {
 
     // reporter type. Defaults to zipkin, in the future it will change to otlp.
     TraceReporterType trace_reporter_type = 5;
+
 }
 
 // Opa covers the options related to the mechanics for getting Open Policy Agent configuration file.

--- a/config.proto
+++ b/config.proto
@@ -31,8 +31,8 @@ message AgentConfig {
     // javaagent has the configs specific to javaagent
     JavaAgent javaagent = 6;
 
-    // resources map define the static list of resources which is configured on the tracer
-    map<string, string> resources = 7;
+    // resource_attributes map define the static list of resources which is configured on the tracer
+    map<string, string> resource_attributes = 7;
 }
 
 // Reporting covers the options related to the mechanics for sending data to the


### PR DESCRIPTION
resources map defined in agent config can be used to initialize
the tracer with a static list of resources which is sent as part
of resource span.
