### PR TITLE
Update trace reporter type to default to none

### DIFF
--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -8,7 +8,7 @@ Agents can be configured using environment variables:
 | Name | Description |
 |------|-------------|
 | HT_SERVICE_NAME | Identifies the service/process running e.g. "my service" |
-| HT_REPORTING_ENDPOINT | Represents the endpoint for reporting the traces e.g. http://api.traceable.ai:9411/api/v2/spans |
+| HT_REPORTING_ENDPOINT | Represents the endpoint for reporting the traces For ZIPKIN reporter type use http://api.traceable.ai:9411/api/v2/spans For OTLP reporter type use http://api.traceable.ai:4317 |
 | HT_REPORTING_SECURE | When `true`, connects to endpoints over TLS. |
 | HT_REPORTING_TOKEN | User specific token to access Traceable API |
 | HT_REPORTING_OPA_ENDPOINT | Represents the endpoint for polling OPA config file e.g. http://opa.traceableai:8181/ |

--- a/config.proto
+++ b/config.proto
@@ -52,7 +52,8 @@ message Reporting {
     // opa describes the setting related to the Open Policy Agent
     Opa opa = 4;
 
-    // reporter type for traces. ZIPKIN or OTLP
+    // reporter type for traces.
+    // Agents should set a default type as ZIPKIN or OTLP while creating default config
     TraceReporterType trace_reporter_type = 5;
 }
 
@@ -111,7 +112,7 @@ enum PropagationFormat {
 enum TraceReporterType {
 
     // Default to none
-    TRACE_REPORTER_TYPE_UNSPECIFIED = 0;
+    UNSPECIFIED = 0;
 
     // Zipkin protobuf reporting format.
     // see https://github.com/openzipkin/zipkin-api

--- a/config.proto
+++ b/config.proto
@@ -52,7 +52,7 @@ message Reporting {
     // opa describes the setting related to the Open Policy Agent
     Opa opa = 4;
 
-    // reporter type. Defaults to zipkin, in the future it will change to otlp.
+    // reporter type for traces. ZIPKIN or OTLP
     TraceReporterType trace_reporter_type = 5;
 }
 
@@ -109,13 +109,17 @@ enum PropagationFormat {
 
 // TraceReporterType represents the reporting format for trace data.
 enum TraceReporterType {
+
+    // Default to none
+    TRACE_REPORTER_TYPE_UNSPECIFIED = 0;
+
     // Zipkin protobuf reporting format.
     // see https://github.com/openzipkin/zipkin-api
-    ZIPKIN = 0;
+    ZIPKIN = 1;
 
     // OpenTelemetry protobuf reporting format.
     // see https://github.com/open-telemetry/opentelemetry-proto
-    OTLP = 1;
+    OTLP = 2;
 }
 
 // JavaAgent has the configs specific to javaagent

--- a/config.proto
+++ b/config.proto
@@ -53,7 +53,6 @@ message Reporting {
     Opa opa = 4;
 
     // reporter type for traces.
-    // Agents should set a default type as ZIPKIN or OTLP while creating default config
     TraceReporterType trace_reporter_type = 5;
 }
 
@@ -111,7 +110,7 @@ enum PropagationFormat {
 // TraceReporterType represents the reporting format for trace data.
 enum TraceReporterType {
 
-    // Default to none
+    // Default to none. Agent will use it's default reporting type
     UNSPECIFIED = 0;
 
     // Zipkin protobuf reporting format.


### PR DESCRIPTION
Updating trace reporter type to default to unspecified. Since this is an enum, the value at 0 is taken as default. We need to be able to set the default in agents, so it should be unspecified. 
This is required because if we do not use UNSPECIFIED, the agents will not know if the value is specified by a user in config-file or it is the default coming from agent-config. So the agents were not able set any other default other than the one here. 