### PR TITLE
Add custom data capture endpoints

### DIFF
--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -26,3 +26,4 @@ Agents can be configured using environment variables:
 | HT_PROPAGATION_FORMATS | List the supported propagation formats e.g. `HT_PROPAGATION_FORMATS="B3,TRACECONTEXT"`. |
 | HT_ENABLED | When `false`, disables the agent |
 | HT_JAVAAGENT_FILTER_JAR_PATHS | Is the list of path to filter jars, separated by `,`. |
+| HT_CUSTOM_DATA_CAPTURE_ENDPOINTS | List the custom endpoints with respective data capture rules. |

--- a/config.proto
+++ b/config.proto
@@ -33,6 +33,9 @@ message AgentConfig {
 
     // resource_attributes map define the static list of resources which is configured on the tracer
     map<string, string> resource_attributes = 7;
+
+    // custom_data_capture_endpoints list the custom endpoints with respective data capture rules
+    repeated CustomDataCaptureEndpoint custom_data_capture_endpoints = 8;
 }
 
 // Reporting covers the options related to the mechanics for sending data to the
@@ -126,4 +129,18 @@ enum TraceReporterType {
 message JavaAgent {
     // filter_jar_paths is the list of path to filter jars, separated by `,`
     repeated google.protobuf.StringValue filter_jar_paths = 1;
+}
+
+// CustomDataCaptureEndpoint represents a custom data capture rule for an endpoint that matches
+// the given url pattern and host header
+message CustomDataCaptureEndpoint {
+
+    // data_capture describes the data being captured by instrumentation for this endpoint
+    DataCapture data_capture = 1;
+
+    // url_pattern describes the url pattern to match for this endpoint
+    google.protobuf.StringValue url_pattern = 2;
+
+    // host_header describes the host header to match for this endpoint
+    google.protobuf.StringValue host_header = 3;
 }


### PR DESCRIPTION
Add custom data capture endpoints which can be used to define custom data capture rules for specific endpoints. 
For example: If a user does not want to capture any data only for a specific endpoint that matches a url pattern and a host header, they can set the fields in this custom data capture to false. 