### PR TITLE
Allow unknown fields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ generate-proto: ## generates code for all languages
 	$(MAKE) -C ./tools/go-generator
 
 	@echo "Go Tidy generated modules."
-	@find $(PWD)/gen/go \( -name vendor -o -name '[._].*' -o -name node_modules \) -prune -o -name go.mod -print | sed 's:/go.mod::' | xargs -I {} bash -c 'cd {}; go mod tidy'
+	@find $(PWD)/gen/go \( -name vendor -o -name '[._].*' -o -name node_modules \) -prune -o -name go.mod -print | sed 's:/go.mod::' | xargs -I {} bash -c 'cd {}; go mod tidy -go=1.15'
 
 generate-env-vars: init-git-submodule ## Generates the ENV_VARS.md with all environment variables.
 	docker build -t hypertrace/agent-config/env-vars-generator tools/env-vars-generator

--- a/gen/go/go.mod
+++ b/gen/go/go.mod
@@ -1,11 +1,17 @@
 module github.com/hypertrace/agent-config/gen/go
 
-go 1.16
+go 1.17
 
 require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/protobuf v1.5.2
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/protobuf v1.27.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/gen/go/go.mod
+++ b/gen/go/go.mod
@@ -1,17 +1,11 @@
 module github.com/hypertrace/agent-config/gen/go
 
-go 1.17
+go 1.15
 
 require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/protobuf v1.5.2
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/protobuf v1.27.1
-)
-
-require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/gen/go/v1/loader.go
+++ b/gen/go/v1/loader.go
@@ -3,6 +3,7 @@
 package v1
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -60,6 +61,7 @@ func getInt32Env(name string) (int32, bool) {
 
 // loadFromFile loads the agent config from a file
 func loadFromFile(c *AgentConfig, filename string) error {
+	unmarshaler := &jsonpb.Unmarshaler{AllowUnknownFields: true}
 	switch ext := filepath.Ext(filename); ext {
 	case ".json":
 		freader, err := os.Open(filename)
@@ -70,7 +72,7 @@ func loadFromFile(c *AgentConfig, filename string) error {
 		// unmarshalers as the wrapped values aren't scalars but of type Message, hence they
 		// have object structure in json e.g. myBoolVal: {Value: true} instead of myBoolVal:true
 		// jsonpb is meant to solve this problem.
-		return jsonpb.Unmarshal(freader, c)
+		return unmarshaler.Unmarshal(freader, c)
 	case ".yaml", ".yml":
 		fcontent, err := ioutil.ReadFile(filename)
 		if err != nil {
@@ -83,7 +85,7 @@ func loadFromFile(c *AgentConfig, filename string) error {
 		if err != nil {
 			return fmt.Errorf("failed to parse file %q: %v", filename, err)
 		}
-		return jsonpb.UnmarshalString(string(fcontentAsJSON), c)
+		return unmarshaler.Unmarshal(bytes.NewReader(fcontentAsJSON), c)
 	default:
 		return fmt.Errorf("unknown extension: %s", ext)
 	}

--- a/gen/go/v1/loader_test.go
+++ b/gen/go/v1/loader_test.go
@@ -61,3 +61,9 @@ func TestGetArrayStringEnv(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, []string{"a", "b"}, vals)
 }
+
+func TestLoadFromFileAcceptsUnknownFields(t *testing.T) {
+	cfg := &AgentConfig{}
+	err := loadFromFile(cfg, "./testdata/config.yaml")
+	assert.NoError(t, err)
+}

--- a/gen/go/v1/options.go
+++ b/gen/go/v1/options.go
@@ -13,7 +13,7 @@ type opts struct {
 	defaultConfig *AgentConfig
 }
 
-var defaultOptions = opts{
+var defaultOptions = opts {
 	prefix:        "HT_",
 	defaultConfig: &AgentConfig{},
 }

--- a/gen/go/v1/testdata/config.yaml
+++ b/gen/go/v1/testdata/config.yaml
@@ -1,0 +1,1 @@
+unknown_field_123: 456

--- a/tools/go-generator/cmd/generator/_templates/loader.go.tmpl
+++ b/tools/go-generator/cmd/generator/_templates/loader.go.tmpl
@@ -3,6 +3,7 @@
 package v1
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -60,6 +61,7 @@ func getInt32Env(name string) (int32, bool) {
 
 // loadFromFile loads the agent config from a file
 func loadFromFile(c *{{ .MainType}}, filename string) error {
+	unmarshaler := &jsonpb.Unmarshaler{AllowUnknownFields: true}
 	switch ext := filepath.Ext(filename); ext {
 	case ".json":
 		freader, err := os.Open(filename)
@@ -70,7 +72,7 @@ func loadFromFile(c *{{ .MainType}}, filename string) error {
 		// unmarshalers as the wrapped values aren't scalars but of type Message, hence they
 		// have object structure in json e.g. myBoolVal: {Value: true} instead of myBoolVal:true
 		// jsonpb is meant to solve this problem.
-		return jsonpb.Unmarshal(freader, c)
+		return unmarshaler.Unmarshal(freader, c)
 	case ".yaml", ".yml":
 		fcontent, err := ioutil.ReadFile(filename)
 		if err != nil {
@@ -83,7 +85,7 @@ func loadFromFile(c *{{ .MainType}}, filename string) error {
 		if err != nil {
 			return fmt.Errorf("failed to parse file %q: %v", filename, err)
 		}
-		return jsonpb.UnmarshalString(string(fcontentAsJSON), c)
+		return unmarshaler.Unmarshal(bytes.NewReader(fcontentAsJSON), c)
 	default:
 		return fmt.Errorf("unknown extension: %s", ext)
 	}

--- a/tools/go-generator/cmd/generator/_templates/loader_test.go.tmpl
+++ b/tools/go-generator/cmd/generator/_templates/loader_test.go.tmpl
@@ -61,3 +61,9 @@ func TestGetArrayStringEnv(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, []string{"a", "b"}, vals)
 }
+
+func TestLoadFromFileAcceptsUnknownFields(t *testing.T) {
+	cfg := &{{ .MainType}}{}
+	err := loadFromFile(cfg, "./testdata/config.yaml")
+	assert.NoError(t, err)
+}

--- a/tools/go-generator/cmd/generator/_templates/testdata/config.yaml
+++ b/tools/go-generator/cmd/generator/_templates/testdata/config.yaml
@@ -1,0 +1,1 @@
+unknown_field_123: 456


### PR DESCRIPTION
## Description

This PR adds support for unmarshaling unknown fields. This is specially useful for cases like in https://github.com/Traceableai/goagent/blob/main/config/loaders.go#L23 where different configs are unmarshaled from the same file.