### PR TITLE
Remove OPA configuration options

### DIFF
--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -11,9 +11,6 @@ Agents can be configured using environment variables:
 | HT_REPORTING_ENDPOINT | Represents the endpoint for reporting the traces For ZIPKIN reporter type use http://api.traceable.ai:9411/api/v2/spans For OTLP reporter type use http://api.traceable.ai:4317 |
 | HT_REPORTING_SECURE | When `true`, connects to endpoints over TLS. |
 | HT_REPORTING_TOKEN | User specific token to access Traceable API |
-| HT_REPORTING_OPA_ENDPOINT | Represents the endpoint for polling OPA config file e.g. http://opa.traceableai:8181/ |
-| HT_REPORTING_OPA_POLL_PERIOD_SECONDS | Poll period in seconds to query OPA service |
-| HT_REPORTING_OPA_ENABLED | When `true` Open Policy Agent evaluation is enabled to block request |
 | HT_REPORTING_CERT_FILE | Certificate file containing the CA to verify the server's certificate. This is for private certificates. If this is set then `secure` above should also be set to `true`. |
 | HT_REPORTING_METRIC_ENDPOINT | Represents the endpoint for reporting the metrics For OTLP metric reporter type use http://api.traceable.ai:4317 |
 | HT_DATA_CAPTURE_HTTP_HEADERS_REQUEST | When `false` it disables the capture for the request in a client/request operation |

--- a/proto/hypertrace/agent/config/v1/config.proto
+++ b/proto/hypertrace/agent/config/v1/config.proto
@@ -49,9 +49,6 @@ message Reporting {
     // user specific token to access Traceable API
     google.protobuf.StringValue token = 3;
 
-    // opa describes the setting related to the Open Policy Agent
-    Opa opa = 4;
-
     // reporter type for traces.
     TraceReporterType trace_reporter_type = 5;
 
@@ -66,19 +63,6 @@ message Reporting {
 
     // reporter type for metrics.
     MetricReporterType metric_reporter_type = 8;
-}
-
-// Opa covers the options related to the mechanics for getting Open Policy Agent configuration file.
-// The client should use secure and token option from reporting settings.
-message Opa {
-    // endpoint represents the endpoint for polling OPA config file e.g. http://opa.traceableai:8181/
-    google.protobuf.StringValue endpoint = 1;
-
-    // poll period in seconds to query OPA service
-    google.protobuf.Int32Value poll_period_seconds  = 2;
-
-    // when `true` Open Policy Agent evaluation is enabled to block request
-    google.protobuf.BoolValue enabled = 3;
 }
 
 // Message describes what message should be considered for certain DataCapture option


### PR DESCRIPTION
## Description
The OPA configuration values no longer need to be referenced from Hypertrace. They should be removed to avoid confusion

### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
I could not find any reference to OPA on docs.hypertrace.org


